### PR TITLE
[R] tools: sampled regression compare

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -8,3 +8,11 @@
   - `render-shud-cfg`：从 `profiles.<name>.shud` 渲染 SHUD 的 `.cfg` 覆盖文件并补丁 `.cfg.para`（用于 NetCDF forcing/output 迁移）
 - `tools/run_qhh_baseline_autoshud.sh`：运行 QHH 的 baseline（AutoSHUD Step1–Step3，生成 SHUD 静态输入 + forcing CSV）
 - `tools/run_qhh_baseline.sh`：一键跑完 baseline（AutoSHUD Step1–Step3 + 调用 `SHUD/shud` 运行）
+- `tools/compare_forcing.py`：forcing 抽样对比（baseline CSV vs NetCDF forcing）
+  - 依赖：`python3 -m pip install netCDF4 numpy`
+  - 示例：
+    - `python3 tools/compare_forcing.py --baseline-run runs/qhh/baseline --nc-run runs/qhh/nc --prj qhh --stations 0,1,2 --t-min 0,180 --out-json runs/qhh/compare/forcing.json`
+- `tools/compare_output.py`：输出抽样对比（legacy *.dat vs NetCDF variable）
+  - 依赖：`python3 -m pip install netCDF4 numpy`
+  - 示例（Phase B 完成后）：
+    - `python3 tools/compare_output.py --legacy-bin runs/qhh/baseline/output/qhh.out/qhh.eleysurf.dat --netcdf runs/qhh/nc/output_netcdf/qhh.ele.nc --var y_surf --obj-dim nface --times-min 0,60 --indices 1,2,3 --out-json runs/qhh/compare/output.json`

--- a/tools/compare_forcing.py
+++ b/tools/compare_forcing.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""
+Sampled forcing regression compare: baseline CSV vs NetCDF forcing.
+
+This tool is intentionally sampled (not full-grid/full-time) to keep comparisons
+fast and reviewable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import dataclasses
+import datetime as dt
+import glob
+import json
+import math
+import os
+import sys
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+def _eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def _parse_int_list(s: str) -> List[int]:
+    out: List[int] = []
+    for part in (p.strip() for p in s.split(",")):
+        if not part:
+            continue
+        out.append(int(part))
+    return out
+
+
+def _parse_float_list(s: str) -> List[float]:
+    out: List[float] = []
+    for part in (p.strip() for p in s.split(",")):
+        if not part:
+            continue
+        out.append(float(part))
+    return out
+
+
+def _zfill(v: int, w: int) -> str:
+    return str(v).zfill(w)
+
+
+def _parse_yyyymmdd(v: int) -> dt.datetime:
+    y = v // 10000
+    m = (v // 100) % 100
+    d = v % 100
+    return dt.datetime(y, m, d, 0, 0, 0, tzinfo=dt.timezone.utc)
+
+
+def _yyyymm_from_forc_start(forc_start_yyyymmdd: int, t_min: float) -> str:
+    base = _parse_yyyymmdd(forc_start_yyyymmdd)
+    t = base + dt.timedelta(minutes=float(t_min))
+    return f"{t.year:04d}{t.month:02d}"
+
+
+def _read_kv_cfg(path: str) -> Dict[str, str]:
+    kv: Dict[str, str] = {}
+    with open(path, "r", encoding="utf-8") as f:
+        for line_no, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                raise ValueError(f"Invalid KEY VALUE line at {path}:{line_no}: {raw!r}")
+            key = parts[0].strip().upper()
+            val = parts[1].strip()
+            kv[key] = val
+    return kv
+
+
+@dataclasses.dataclass(frozen=True)
+class ForcStation:
+    idx0: int
+    lon_deg: float
+    lat_deg: float
+    filename: str
+
+
+@dataclasses.dataclass(frozen=True)
+class TsdForc:
+    num_forc: int
+    forc_start_yyyymmdd: int
+    rel_path: str
+    stations: List[ForcStation]
+
+
+def _read_tsd_forc(path: str) -> TsdForc:
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    if not lines:
+        raise ValueError(f"Empty tsd.forc: {path}")
+
+    head = lines[0].split()
+    if len(head) < 2:
+        raise ValueError(f"Invalid tsd.forc header: {path}: {lines[0]!r}")
+    num_forc = int(head[0])
+    forc_start = int(head[1])
+
+    rel_path = ""
+    if len(lines) >= 2:
+        rel_path = lines[1].strip()
+
+    stations: List[ForcStation] = []
+    for raw in lines[3:]:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 7:
+            raise ValueError(f"Invalid station record in {path}: {raw!r}")
+        # ID Lon Lat X Y Z Filename
+        idx0 = len(stations)
+        lon = float(parts[1])
+        lat = float(parts[2])
+        filename = parts[6]
+        stations.append(ForcStation(idx0=idx0, lon_deg=lon, lat_deg=lat, filename=filename))
+
+    if len(stations) != num_forc:
+        raise ValueError(f"NumForc mismatch in {path}: header={num_forc}, parsed={len(stations)}")
+
+    return TsdForc(num_forc=num_forc, forc_start_yyyymmdd=forc_start, rel_path=rel_path, stations=stations)
+
+
+def _resolve_station_csv_path(tsd_dir: str, rel_path: str, filename: str) -> str:
+    if rel_path:
+        return os.path.normpath(os.path.join(tsd_dir, rel_path, filename))
+    return os.path.normpath(os.path.join(tsd_dir, filename))
+
+
+def _read_station_csv_at(path: str, t_min: float) -> Tuple[float, float, float, float, float]:
+    # CSV format:
+    # line1: nrow ncol start_yyyymmdd [end_yyyymmdd]
+    # line2: header
+    # data: time_day 5vars...
+    with open(path, "r", encoding="utf-8") as f:
+        _ = f.readline()
+        _ = f.readline()
+
+        prev_t: Optional[float] = None
+        prev_vals: Optional[Tuple[float, float, float, float, float]] = None
+
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) < 6:
+                raise ValueError(f"Invalid forcing csv row: {path}: {raw!r}")
+            time_day = float(parts[0])
+            tt = time_day * 1440.0
+            vals = tuple(float(x) for x in parts[1:6])
+
+            if tt > t_min + 1e-9:
+                if prev_vals is not None:
+                    return prev_vals
+                return vals  # t_min before first data row
+
+            prev_t = tt
+            prev_vals = vals
+
+        if prev_vals is None:
+            raise ValueError(f"No data rows in forcing csv: {path}")
+        return prev_vals
+
+
+def _require_netCDF4() -> Any:
+    try:
+        import netCDF4  # type: ignore
+
+        return netCDF4
+    except Exception as e:
+        raise RuntimeError(
+            "Python package 'netCDF4' is required for NetCDF forcing comparison.\n"
+            "Install:\n"
+            "  python3 -m pip install netCDF4 numpy\n"
+        ) from e
+
+
+def _resolve_single_glob(pattern: str) -> str:
+    matches = sorted(glob.glob(pattern))
+    if len(matches) != 1:
+        raise ValueError(f"Glob must match exactly 1 file, got {len(matches)}: {pattern}")
+    return matches[0]
+
+
+def _parse_units_since(units: str) -> Tuple[float, dt.datetime]:
+    # e.g. "hours since 1900-01-01 00:00:0.0"
+    u = units.strip().lower()
+    if "since" not in u:
+        raise ValueError(f"Unsupported time units (missing since): {units!r}")
+    unit_part, base_part = u.split("since", 1)
+    unit_part = unit_part.strip()
+    base_part = base_part.strip().replace("t", " ")
+
+    if unit_part.startswith("second"):
+        factor_min = 1.0 / 60.0
+    elif unit_part.startswith("minute"):
+        factor_min = 1.0
+    elif unit_part.startswith("hour"):
+        factor_min = 60.0
+    elif unit_part.startswith("day"):
+        factor_min = 1440.0
+    else:
+        raise ValueError(f"Unsupported time unit: {units!r}")
+
+    # base date
+    date_s = base_part.split()[0]
+    time_s = base_part.split()[1] if len(base_part.split()) >= 2 else "00:00:00"
+    y, m, d = (int(x) for x in date_s.split("-"))
+
+    hh, mm, ss = 0, 0, 0
+    tparts = time_s.split(":")
+    if len(tparts) >= 2:
+        hh = int(tparts[0])
+        mm = int(tparts[1])
+        # ignore seconds fractional
+        if len(tparts) >= 3:
+            try:
+                ss = int(float(tparts[2]))
+            except Exception:
+                ss = 0
+    base = dt.datetime(y, m, d, hh, mm, ss, tzinfo=dt.timezone.utc)
+    return factor_min, base
+
+
+def _cmfd2_precip_units_kind(units: str) -> str:
+    u = units.strip().lower()
+    if "kg" in u and ("m-2" in u or "m**-2" in u) and ("s-1" in u or "s**-1" in u):
+        return "KG_M2_S"
+    if "mm" in u and ("hr" in u or "h-1" in u or "h**-1" in u):
+        return "MM_HR"
+    if "mm" in u and ("day" in u or "d-1" in u or "d**-1" in u):
+        return "MM_DAY"
+    return "UNKNOWN"
+
+
+def _read_netcdf_point(
+    ds: Any,
+    *,
+    var_name: str,
+    dim_time: str,
+    dim_lat: str,
+    dim_lon: str,
+    time_idx: int,
+    lat_idx: int,
+    lon_idx: int,
+) -> float:
+    var = ds.variables[var_name]
+    dims = list(var.dimensions)
+    index: List[int] = []
+    for d in dims:
+        if d == dim_time:
+            index.append(time_idx)
+        elif d == dim_lat:
+            index.append(lat_idx)
+        elif d == dim_lon:
+            index.append(lon_idx)
+        else:
+            index.append(0)
+    v = var[tuple(index)]
+    # netCDF4 may return masked arrays
+    try:
+        import numpy as np  # type: ignore
+
+        if isinstance(v, np.ma.MaskedArray):
+            if bool(np.ma.is_masked(v)):
+                raise ValueError(f"masked value for var={var_name} at idx={index}")
+            v = v.item()
+        elif hasattr(v, "item"):
+            v = v.item()
+    except Exception:
+        pass
+    if v is None or not math.isfinite(float(v)):
+        raise ValueError(f"non-finite value for var={var_name} at idx={index}")
+    return float(v)
+
+
+def _cmfd2_netcdf_at(
+    *,
+    forcing_cfg: Dict[str, str],
+    forc_start_yyyymmdd: int,
+    station_lon_deg: float,
+    station_lat_deg: float,
+    t_min: float,
+) -> Dict[str, float]:
+    netCDF4 = _require_netCDF4()
+
+    product = forcing_cfg.get("PRODUCT", "").upper()
+    if product != "CMFD2":
+        raise ValueError(f"Only PRODUCT=CMFD2 is supported for now (got {product!r})")
+
+    data_root = forcing_cfg["DATA_ROOT"]
+    file_pattern = forcing_cfg["LAYOUT_FILE_PATTERN"]
+
+    dim_time = forcing_cfg.get("NC_DIM_TIME", "time")
+    dim_lat = forcing_cfg.get("NC_DIM_LAT", "lat")
+    dim_lon = forcing_cfg.get("NC_DIM_LON", "lon")
+
+    time_var = forcing_cfg.get("TIME_VAR", dim_time)
+    lat_var = forcing_cfg.get("LAT_VAR", dim_lat)
+    lon_var = forcing_cfg.get("LON_VAR", dim_lon)
+
+    yyyymm = _yyyymm_from_forc_start(forc_start_yyyymmdd, t_min)
+
+    def resolve(var_key: str) -> Tuple[str, str]:
+        vname = forcing_cfg[f"NC_VAR_{var_key}"]
+        vdir = forcing_cfg[f"LAYOUT_VAR_DIR_{var_key}"]
+        pat = file_pattern.replace("{var_lower}", vname.lower()).replace("{yyyymm}", yyyymm)
+        full = os.path.join(data_root, vdir, pat)
+        return _resolve_single_glob(full), vname
+
+    f_prec, v_prec = resolve("PREC")
+    f_temp, v_temp = resolve("TEMP")
+    f_shum, v_shum = resolve("SHUM")
+    f_srad, v_srad = resolve("SRAD")
+    f_wind, v_wind = resolve("WIND")
+    f_pres, v_pres = resolve("PRES")
+
+    with netCDF4.Dataset(f_prec, "r") as ds_grid:
+        lat_arr = ds_grid.variables[lat_var][:]
+        lon_arr = ds_grid.variables[lon_var][:]
+        lon_min = float(lon_arr.min())
+        lon_max = float(lon_arr.max())
+        lon_0360 = lon_min >= 0.0 and lon_max > 180.0
+
+        slon = float(station_lon_deg)
+        if lon_0360:
+            if slon < 0.0:
+                slon += 360.0
+            while slon >= 360.0:
+                slon -= 360.0
+
+        # nearest search
+        lat_idx = int(abs(lat_arr - station_lat_deg).argmin())
+        lon_idx = int(abs(lon_arr - slon).argmin())
+
+        # time index (step function)
+        time_vals = ds_grid.variables[time_var][:]
+        units = getattr(ds_grid.variables[time_var], "units", None)
+        if not isinstance(units, str) or not units.strip():
+            raise ValueError(f"time variable missing units: {f_prec}:{time_var}")
+        factor_min, base_dt = _parse_units_since(units)
+        forc_base = _parse_yyyymmdd(forc_start_yyyymmdd)
+
+        tmins = [(base_dt + dt.timedelta(minutes=float(v) * factor_min) - forc_base).total_seconds() / 60.0 for v in time_vals]
+        i = bisect.bisect_right(tmins, float(t_min)) - 1
+        if i < 0:
+            i = 0
+
+    # open per-var files for point reads
+    with netCDF4.Dataset(f_temp, "r") as ds_temp, netCDF4.Dataset(f_shum, "r") as ds_shum, netCDF4.Dataset(
+        f_srad, "r"
+    ) as ds_srad, netCDF4.Dataset(f_wind, "r") as ds_wind, netCDF4.Dataset(f_pres, "r") as ds_pres, netCDF4.Dataset(
+        f_prec, "r"
+    ) as ds_prec:
+        prec_raw = _read_netcdf_point(
+            ds_prec, var_name=v_prec, dim_time=dim_time, dim_lat=dim_lat, dim_lon=dim_lon, time_idx=i, lat_idx=lat_idx, lon_idx=lon_idx
+        )
+        temp_k = _read_netcdf_point(
+            ds_temp, var_name=v_temp, dim_time=dim_time, dim_lat=dim_lat, dim_lon=dim_lon, time_idx=i, lat_idx=lat_idx, lon_idx=lon_idx
+        )
+        shum = _read_netcdf_point(
+            ds_shum, var_name=v_shum, dim_time=dim_time, dim_lat=dim_lat, dim_lon=dim_lon, time_idx=i, lat_idx=lat_idx, lon_idx=lon_idx
+        )
+        srad = _read_netcdf_point(
+            ds_srad, var_name=v_srad, dim_time=dim_time, dim_lat=dim_lat, dim_lon=dim_lon, time_idx=i, lat_idx=lat_idx, lon_idx=lon_idx
+        )
+        wind = _read_netcdf_point(
+            ds_wind, var_name=v_wind, dim_time=dim_time, dim_lat=dim_lat, dim_lon=dim_lon, time_idx=i, lat_idx=lat_idx, lon_idx=lon_idx
+        )
+        pres = _read_netcdf_point(
+            ds_pres, var_name=v_pres, dim_time=dim_time, dim_lat=dim_lat, dim_lon=dim_lon, time_idx=i, lat_idx=lat_idx, lon_idx=lon_idx
+        )
+
+        # precip units auto-detect
+        units = getattr(ds_prec.variables[v_prec], "units", "")
+        kind = _cmfd2_precip_units_kind(units if isinstance(units, str) else "")
+        if kind == "KG_M2_S":
+            prcp_mm_day = prec_raw * 86400.0
+        elif kind == "MM_HR":
+            prcp_mm_day = prec_raw * 24.0
+        elif kind == "MM_DAY":
+            prcp_mm_day = prec_raw
+        else:
+            raise ValueError(f"unknown CMFD2 precip units: {units!r}")
+
+        # match AutoSHUD min threshold behavior
+        if prcp_mm_day < 0.0001:
+            prcp_mm_day = 0.0
+        if prcp_mm_day < 0.0:
+            prcp_mm_day = 0.0
+
+        temp_c = temp_k - 273.15
+        rh_percent = 0.263 * pres * shum / math.exp(17.67 * (temp_k - 273.15) / (temp_k - 29.65))
+        rh_percent = max(0.0, min(100.0, float(rh_percent)))
+        rh_1 = rh_percent / 100.0
+        wind_ms = abs(wind)
+        rn_wm2 = srad
+
+        return {
+            "Precip_mm_day": float(prcp_mm_day),
+            "Temp_C": float(temp_c),
+            "RH_1": float(rh_1),
+            "Wind_m_s": float(wind_ms),
+            "RN_W_m2": float(rn_wm2),
+        }
+
+
+def _summarize_diffs(samples: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    vars_ = ["Precip_mm_day", "Temp_C", "RH_1", "Wind_m_s", "RN_W_m2"]
+    summary: Dict[str, Any] = {}
+    for v in vars_:
+        diffs = [float(s["diff"][v]) for s in samples]
+        absdiffs = [abs(x) for x in diffs]
+        summary[v] = {
+            "max_abs": max(absdiffs) if absdiffs else 0.0,
+            "mean": sum(diffs) / len(diffs) if diffs else 0.0,
+            "mean_abs": sum(absdiffs) / len(absdiffs) if absdiffs else 0.0,
+        }
+    return summary
+
+
+def main(argv: Sequence[str]) -> int:
+    p = argparse.ArgumentParser(description="Sampled forcing compare: baseline CSV vs NetCDF (CMFD2)")
+    p.add_argument("--baseline-run", required=True, help="Baseline run_dir (contains input/<prj>/<prj>.tsd.forc)")
+    p.add_argument("--nc-run", required=True, help="NC run_dir (contains input/<prj>/<prj>.cfg.forcing)")
+    p.add_argument("--prj", required=True, help="Project name (e.g. qhh)")
+    p.add_argument("--stations", default="0,1,2", help="0-based station indices, comma-separated (default: 0,1,2)")
+    p.add_argument("--t-min", default="0,180", help="Sample times in minutes since ForcStartTime, comma-separated (default: 0,180)")
+    p.add_argument("--out-json", default="", help="Write JSON report to this path (optional)")
+    p.add_argument("--fail-max-abs", type=float, default=math.inf, help="Fail if any variable max_abs exceeds this")
+
+    args = p.parse_args(list(argv))
+
+    baseline_run = os.path.abspath(args.baseline_run)
+    nc_run = os.path.abspath(args.nc_run)
+    prj = str(args.prj)
+
+    stations_idx = _parse_int_list(args.stations)
+    times_min = _parse_float_list(args.t_min)
+
+    baseline_tsd_forc = os.path.join(baseline_run, "input", prj, f"{prj}.tsd.forc")
+    tsd = _read_tsd_forc(baseline_tsd_forc)
+    forc_start = tsd.forc_start_yyyymmdd
+
+    baseline_input_dir = os.path.join(baseline_run, "input", prj)
+    forcing_cfg_path = os.path.join(nc_run, "input", prj, f"{prj}.cfg.forcing")
+
+    forcing_cfg = _read_kv_cfg(forcing_cfg_path)
+    # DATA_ROOT is rendered relative to run_dir; resolve here for tool usage.
+    if not os.path.isabs(forcing_cfg.get("DATA_ROOT", "")):
+        forcing_cfg["DATA_ROOT"] = os.path.normpath(os.path.join(nc_run, forcing_cfg["DATA_ROOT"]))
+
+    samples: List[Dict[str, Any]] = []
+
+    for sidx in stations_idx:
+        st = tsd.stations[sidx]
+        csv_path = _resolve_station_csv_path(baseline_input_dir, tsd.rel_path, st.filename)
+        for tmin in times_min:
+            base_vals = _read_station_csv_at(csv_path, tmin)
+            base_map = {
+                "Precip_mm_day": base_vals[0],
+                "Temp_C": base_vals[1],
+                "RH_1": base_vals[2],
+                "Wind_m_s": base_vals[3],
+                "RN_W_m2": base_vals[4],
+            }
+            nc_map = _cmfd2_netcdf_at(
+                forcing_cfg=forcing_cfg,
+                forc_start_yyyymmdd=forc_start,
+                station_lon_deg=st.lon_deg,
+                station_lat_deg=st.lat_deg,
+                t_min=tmin,
+            )
+            diff = {k: float(base_map[k]) - float(nc_map[k]) for k in base_map.keys()}
+            samples.append(
+                {
+                    "station_idx0": sidx,
+                    "t_min": float(tmin),
+                    "station_lon_deg": float(st.lon_deg),
+                    "station_lat_deg": float(st.lat_deg),
+                    "baseline": base_map,
+                    "nc": nc_map,
+                    "diff": diff,
+                }
+            )
+
+    summary = _summarize_diffs(samples)
+    report = {
+        "baseline_run": baseline_run,
+        "nc_run": nc_run,
+        "prj": prj,
+        "forc_start_yyyymmdd": forc_start,
+        "stations_idx0": stations_idx,
+        "times_min": times_min,
+        "summary": summary,
+        "samples": samples,
+    }
+
+    # Print a compact summary
+    print("== Forcing compare summary (baseline - nc) ==")
+    for v, s in summary.items():
+        print(f"- {v}: max_abs={s['max_abs']:.6g} mean={s['mean']:.6g} mean_abs={s['mean_abs']:.6g}")
+
+    # Optional JSON output
+    if args.out_json:
+        out_path = os.path.abspath(args.out_json)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        print(f"Wrote: {out_path}")
+
+    # Optional threshold failure
+    max_over = []
+    for v, s in summary.items():
+        if float(s["max_abs"]) > float(args.fail_max_abs):
+            max_over.append((v, s["max_abs"]))
+    if max_over:
+        _eprint("ERROR: max_abs diff exceeded threshold:")
+        for v, mx in max_over:
+            _eprint(f"- {v}: {mx}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+

--- a/tools/compare_output.py
+++ b/tools/compare_output.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+Sampled output regression compare: legacy (binary/ASCII) vs NetCDF.
+
+The NetCDF output contract is still evolving (Phase B). This tool focuses on:
+- parsing SHUD legacy binary output (*.dat) deterministically
+- comparing sampled (time, index) points against NetCDF variables
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import os
+import struct
+import sys
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+def _eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def _parse_int_list(s: str) -> List[int]:
+    out: List[int] = []
+    for part in (p.strip() for p in s.split(",")):
+        if not part:
+            continue
+        out.append(int(part))
+    return out
+
+
+def _parse_float_list(s: str) -> List[float]:
+    out: List[float] = []
+    for part in (p.strip() for p in s.split(",")):
+        if not part:
+            continue
+        out.append(float(part))
+    return out
+
+
+def _require_netCDF4() -> Any:
+    try:
+        import netCDF4  # type: ignore
+
+        return netCDF4
+    except Exception as e:
+        raise RuntimeError(
+            "Python package 'netCDF4' is required for NetCDF output comparison.\n"
+            "Install:\n"
+            "  python3 -m pip install netCDF4 numpy\n"
+        ) from e
+
+
+@dataclasses.dataclass
+class LegacyBin:
+    start_time: float
+    num_var: int
+    icol_1based: List[int]
+    times_min: List[float]
+    values: List[List[float]]  # rows: [num_var]
+
+
+def _read_legacy_bin(path: str) -> LegacyBin:
+    with open(path, "rb") as f:
+        header = f.read(1024)
+        if len(header) != 1024:
+            raise ValueError(f"Invalid legacy bin header size: {path}")
+
+        start_time = struct.unpack("d", f.read(8))[0]
+        num_var = int(struct.unpack("d", f.read(8))[0])
+        icol = list(struct.unpack(f"{num_var}d", f.read(8 * num_var)))
+        icol_1based = [int(round(x)) for x in icol]
+
+        times: List[float] = []
+        rows: List[List[float]] = []
+        rec_size = 8 * (1 + num_var)
+        while True:
+            blob = f.read(rec_size)
+            if not blob:
+                break
+            if len(blob) != rec_size:
+                raise ValueError(f"Truncated legacy bin record: {path}")
+            t = struct.unpack_from("d", blob, 0)[0]
+            vals = list(struct.unpack_from(f"{num_var}d", blob, 8))
+            times.append(float(t))
+            rows.append([float(x) for x in vals])
+
+    return LegacyBin(
+        start_time=float(start_time),
+        num_var=num_var,
+        icol_1based=icol_1based,
+        times_min=times,
+        values=rows,
+    )
+
+
+def _find_time_index(times: Sequence[float], t_min: float, tol: float) -> int:
+    best = -1
+    best_err = float("inf")
+    for i, t in enumerate(times):
+        err = abs(float(t) - float(t_min))
+        if err < best_err:
+            best = i
+            best_err = err
+    if best < 0 or best_err > tol:
+        raise ValueError(f"time not found within tol={tol}: t_min={t_min}, best_err={best_err}")
+    return best
+
+
+def _read_netcdf_value(nc_path: str, var_name: str, time_idx: int, obj_idx0: int, time_dim: str, obj_dim: str) -> float:
+    netCDF4 = _require_netCDF4()
+    with netCDF4.Dataset(nc_path, "r") as ds:
+        if var_name not in ds.variables:
+            raise ValueError(f"var not found in NetCDF: {nc_path}: {var_name}")
+        var = ds.variables[var_name]
+        dims = list(var.dimensions)
+        if time_dim not in dims or obj_dim not in dims:
+            raise ValueError(f"var dims do not include {time_dim}/{obj_dim}: {var_name} dims={dims}")
+        index: List[int] = []
+        for d in dims:
+            if d == time_dim:
+                index.append(int(time_idx))
+            elif d == obj_dim:
+                index.append(int(obj_idx0))
+            else:
+                index.append(0)
+        v = var[tuple(index)]
+        try:
+            import numpy as np  # type: ignore
+
+            if isinstance(v, np.ma.MaskedArray):
+                if bool(np.ma.is_masked(v)):
+                    raise ValueError(f"masked value for var={var_name} at idx={index}")
+                v = v.item()
+            elif hasattr(v, "item"):
+                v = v.item()
+        except Exception:
+            pass
+        if v is None or not math.isfinite(float(v)):
+            raise ValueError(f"non-finite value for var={var_name} at idx={index}")
+        return float(v)
+
+
+def main(argv: Sequence[str]) -> int:
+    ap = argparse.ArgumentParser(description="Sampled output compare: legacy *.dat vs NetCDF variable")
+    ap.add_argument("--legacy-bin", required=True, help="Legacy binary output file (*.dat)")
+    ap.add_argument("--netcdf", required=True, help="NetCDF output file (*.nc)")
+    ap.add_argument("--var", required=True, help="NetCDF variable name to compare")
+    ap.add_argument("--time-dim", default="time", help="NetCDF time dimension name (default: time)")
+    ap.add_argument("--obj-dim", default="", help="NetCDF object dimension name (required if not inferable)")
+    ap.add_argument("--times-min", default="", help="Sample times (minutes), comma-separated; default: first 2 records")
+    ap.add_argument("--indices", default="", help="Sample full indices (1-based), comma-separated; default: first 3 icol[]")
+    ap.add_argument("--time-tol", type=float, default=1e-6, help="Time match tolerance (minutes)")
+    ap.add_argument("--out-json", default="", help="Write JSON report (optional)")
+
+    args = ap.parse_args(list(argv))
+    legacy_path = os.path.abspath(args.legacy_bin)
+    nc_path = os.path.abspath(args.netcdf)
+
+    legacy = _read_legacy_bin(legacy_path)
+
+    if not args.times_min:
+        times_min = legacy.times_min[:2]
+    else:
+        times_min = _parse_float_list(args.times_min)
+
+    if not args.indices:
+        indices_1based = legacy.icol_1based[:3]
+    else:
+        indices_1based = _parse_int_list(args.indices)
+
+    # Infer obj_dim if possible
+    obj_dim = args.obj_dim.strip()
+    if not obj_dim:
+        netCDF4 = _require_netCDF4()
+        with netCDF4.Dataset(nc_path, "r") as ds:
+            dims = list(ds.variables[args.var].dimensions)
+            cand = [d for d in dims if d != args.time_dim]
+            if len(cand) == 1:
+                obj_dim = cand[0]
+            else:
+                raise ValueError(f"Cannot infer obj_dim from dims={dims}; pass --obj-dim")
+
+    samples: List[Dict[str, Any]] = []
+
+    # Map legacy icol -> column index
+    col_of_index: Dict[int, int] = {idx: j for j, idx in enumerate(legacy.icol_1based)}
+
+    for t in times_min:
+        ti = _find_time_index(legacy.times_min, float(t), tol=float(args.time_tol))
+        for idx1 in indices_1based:
+            if idx1 not in col_of_index:
+                continue
+            col = col_of_index[idx1]
+            legacy_v = float(legacy.values[ti][col])
+            nc_v = _read_netcdf_value(
+                nc_path,
+                var_name=args.var,
+                time_idx=ti,
+                obj_idx0=int(idx1) - 1,
+                time_dim=args.time_dim,
+                obj_dim=obj_dim,
+            )
+            samples.append(
+                {
+                    "t_min": float(legacy.times_min[ti]),
+                    "index_1based": int(idx1),
+                    "legacy": legacy_v,
+                    "netcdf": nc_v,
+                    "diff": legacy_v - nc_v,
+                }
+            )
+
+    diffs = [abs(float(s["diff"])) for s in samples]
+    report = {
+        "legacy_bin": legacy_path,
+        "netcdf": nc_path,
+        "var": args.var,
+        "time_dim": args.time_dim,
+        "obj_dim": obj_dim,
+        "samples": samples,
+        "summary": {"count": len(samples), "max_abs": max(diffs) if diffs else 0.0, "mean_abs": sum(diffs) / len(diffs) if diffs else 0.0},
+    }
+
+    print("== Output compare summary (legacy - netcdf) ==")
+    print(f"- samples: {report['summary']['count']}")
+    print(f"- max_abs: {report['summary']['max_abs']:.6g}")
+    print(f"- mean_abs: {report['summary']['mean_abs']:.6g}")
+
+    if args.out_json:
+        out_path = os.path.abspath(args.out_json)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        print(f"Wrote: {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+


### PR DESCRIPTION
Links: closes DankerMu/SHUD-NC#3

OpenSpec change id: `add-tools-regression-compare`
- Proposal: https://github.com/DankerMu/SHUD-NC/blob/main/openspec/changes/add-tools-regression-compare/proposal.md
- Tasks: https://github.com/DankerMu/SHUD-NC/blob/main/openspec/changes/add-tools-regression-compare/tasks.md

## Summary
- Add `tools/compare_forcing.py`: sampled forcing compare (baseline CSV vs CMFD2 NetCDF).
- Add `tools/compare_output.py`: sampled legacy binary (*.dat) vs NetCDF variable compare (Phase B-ready).
- Update `tools/README.md` with usage and dependencies.

## Usage
- Install deps:
  - `python3 -m pip install netCDF4 numpy`

## Notes
- `compare_output.py` reads SHUD legacy binary format deterministically (1024B header + StartTime/NumVar/icol + records).
- NetCDF output schema/dim names may still evolve; use `--obj-dim` if inference is ambiguous.
