### PR TITLE
ci: add OpenSpec + python smoke workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  openspec-validate:
+    name: OpenSpec Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install OpenSpec CLI
+        run: npm install -g @fission-ai/openspec@0.19.0
+
+      - name: Validate
+        run: openspec validate --all --strict --no-interactive
+
+  python-smoke:
+    name: Python Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
+      - name: Dependency sanity
+        run: |
+          python -c "import yaml; print('pyyaml ok')"
+
+      - name: Syntax check
+        run: |
+          python -m py_compile tools/shudnc.py tools/compare_forcing.py tools/compare_output.py


### PR DESCRIPTION
Partially addresses #11 (adds CI checks; branch protection settings still need to be enabled).\n\nSummary:\n- Add GitHub Actions workflow to run ✓ spec/meta-runner
✓ spec/shud-build
✓ spec/shud-forcing
✓ spec/shud-output
Totals: 4 passed, 0 failed (4 items).\n- Add lightweight Python smoke checks for tools/*.py.\n\nTest plan:\n- GitHub Actions