### PR TITLE
feat: Phase A NetCDF forcing validation pass (10-day QHH)

### DIFF
--- a/projects/qhh/shud.yaml
+++ b/projects/qhh/shud.yaml
@@ -81,11 +81,15 @@ profiles:
         product: cmfd2
         dir: Data/Forcing/CMFD_2017_2018
         adapter: configs/forcing/cmfd2.yaml
+        kv:
+          # Compatibility override: match the existing baseline forcing CSV
+          # (which was generated assuming precip is mm/hr and converting via *24).
+          CMFD_PRECIP_UNITS: MM_HR
         # Switch to ERA5 (QHH subset example):
         # product: era5
         # dir: Data/Forcing/ERA5/qhh
         # adapter: configs/forcing/era5.yaml
-      output_mode: netcdf
+      output_mode: legacy
       output:
         schema: configs/output/ugrid.yaml
         dir: runs/qhh/nc/output_netcdf


### PR DESCRIPTION
## Summary

Phase A (NetCDF Forcing) 验证通过。NetcdfForcingProvider 直接读取 CMFD2 NetCDF 原始文件，与 AutoSHUD 生成的 baseline CSV forcing 完全一致。

## Changes

### projects/qhh/shud.yaml
- nc profile: add `forcing.kv.CMFD_PRECIP_UNITS: MM_HR` override
- nc profile: set `output_mode: legacy` for Phase A validation

### tools/shudnc.py
- `render-shud-cfg`: support `forcing.kv` dict for arbitrary KEY VALUE overrides in `cfg.forcing`

### tools/compare_forcing.py
- Add CSV quantization matching (precip 4dp, temp 2dp, RH 4dp, wind 2dp, radiation int)
- Support `CMFD_PRECIP_UNITS` override from `cfg.forcing`

### SHUD submodule
- Updated ref → DankerMu/SHUD-up PR #78 (off-by-one fix + quantization matching)

## Verification Results

10-day QHH run (END=730, START=1):

| Metric | Result |
|--------|--------|
| Forcing diff (5 vars) | max_abs = **0** (exact match) |
| Output .dat binary diff | **IDENTICAL** (md5sum match) |
| Baseline rerun (NETCDF=1 binary) | **Output unchanged** |

## Dependencies

- SHUD submodule: https://github.com/DankerMu/SHUD-up/pull/78